### PR TITLE
fix fr bustage

### DIFF
--- a/fr/mail/chrome/messenger/pbValidate.dtd
+++ b/fr/mail/chrome/messenger/pbValidate.dtd
@@ -49,7 +49,6 @@
 
 <!ENTITY enterLicenseTitle.style "">
 <!ENTITY invalidLicenseVersion.style "">
-# do NOT localize entity validationTitle.style
 <!ENTITY validationTitle.style "font-size: 10px;">
 <!ENTITY thanksTitle.style "">
 <!ENTITY invalidLicense.style "">


### PR DESCRIPTION
Title says it all. Bustage caused by a plaintext comment instead of a XML comment inside a DTD file.