### PR TITLE
Fix inline attachment title

### DIFF
--- a/de/mail/chrome/messenger/messenger.properties
+++ b/de/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- Zitat anzeigen -
 hideQuotedText=- Zitat ausblenden -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=Anhänge
-inlineAttachmentTitle1=Anhänge;#1 Anhang;#1 Anhänge
+inlineAttachmentTitle1=#1 Anhang;#1 Anhänge
 inlineSaveAllAttachmentsTitle=speichern
 notDisplayingRemoteContent.label=Entfernte Bilder werden nicht angezeigt.
 loadRemoteImages.label=Bilder Laden

--- a/en-GB/mail/chrome/messenger/messenger.properties
+++ b/en-GB/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- show quoted text -
 hideQuotedText=- hide quoted text -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=attachments
-inlineAttachmentTitle1=attachments;#1 attachment;#1 attachments
+inlineAttachmentTitle1=#1 attachment;#1 attachments
 inlineSaveAllAttachmentsTitle=save
 notDisplayingRemoteContent.label=Remote images are not displayed.
 loadRemoteImages.label=Load Images

--- a/es-ES/mail/chrome/messenger/messenger.properties
+++ b/es-ES/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- mostrar texto citado -
 hideQuotedText=- esconder texto citado -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=adjuntos
-inlineAttachmentTitle1=adjuntos;#1 adjunto;#1 adjuntos
+inlineAttachmentTitle1=#1 adjunto;#1 adjuntos
 inlineSaveAllAttachmentsTitle=guardar
 notDisplayingRemoteContent.label=No se muestran las imágenes remotas.
 loadRemoteImages.label=Cargar imágenes

--- a/fr/mail/chrome/messenger/messenger.properties
+++ b/fr/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- afficher la citation -
 hideQuotedText=- masquer la citation -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=pièces jointes
-inlineAttachmentTitle1=pièces jointes;#1 pièce jointe;#1 pièces jointes
+inlineAttachmentTitle1=#1 pièce jointe;#1 pièces jointes
 inlineSaveAllAttachmentsTitle=Enregistrer
 notDisplayingRemoteContent.label=Les images distantes ne sont pas affichées.
 loadRemoteImages.label=Charger les images

--- a/it/mail/chrome/messenger/messenger.properties
+++ b/it/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- mostra testo citato -
 hideQuotedText=- nascondi testo citato -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=allegati
-inlineAttachmentTitle1=allegati;#1 allegato;#1 allegati
+inlineAttachmentTitle1=#1 allegato;#1 allegati
 inlineSaveAllAttachmentsTitle=salva
 notDisplayingRemoteContent.label=Immagini remote non visualizzate.
 loadRemoteImages.label=Carica immagini

--- a/nl/mail/chrome/messenger/messenger.properties
+++ b/nl/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- geef geciteerde tekst weer -
 hideQuotedText=- verberg geciteerde tekst -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=bijlagen
-inlineAttachmentTitle1=attachments;#1 attachment;#1 attachments
+inlineAttachmentTitle1=#1 attachment;#1 attachments
 inlineSaveAllAttachmentsTitle=opslaan
 notDisplayingRemoteContent.label=Externe Afbeeldingen worden niet weergegeven.
 loadRemoteImages.label=Afbeeldingen weergeven

--- a/pt-BR/mail/chrome/messenger/messenger.properties
+++ b/pt-BR/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- exibir texto citado -
 hideQuotedText=- ocultar texto citado -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=anexos
-inlineAttachmentTitle1=anexos;#1 anexo;#1 anexos
+inlineAttachmentTitle1=#1 anexo;#1 anexos
 inlineSaveAllAttachmentsTitle=salvar
 notDisplayingRemoteContent.label=Imagens remotas não são exibidas.
 loadRemoteImages.label=Carregar imagens

--- a/sv-SE/mail/chrome/messenger/messenger.properties
+++ b/sv-SE/mail/chrome/messenger/messenger.properties
@@ -613,7 +613,7 @@ showQuotedText=- visa citerad text -
 hideQuotedText=- dölj citerad text -
 #LOCALIZATION NOTE #1 is the number of attachments in the message
 inlineAttachmentTitleForNoAttachments=bilagor
-inlineAttachmentTitle1=bilagor;#1 bilaga;#1 bilagor
+inlineAttachmentTitle1=#1 bilaga;#1 bilagor
 inlineSaveAllAttachmentsTitle=spara
 notDisplayingRemoteContent.label=Fjärrhämtade bilder visas inte.
 loadRemoteImages.label=Hämta bilder


### PR DESCRIPTION
These languages only use two plural forms. (I found no other plural form errors in those languages.)