### PR TITLE
Add new filter log strings to translations

### DIFF
--- a/de/mail/chrome/messenger/filter.properties
+++ b/de/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=Nachricht (ID= %1$S) verschoben nach %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=Nachricht (ID= %1$S) kopiert nach %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Filter "%1$S" auf die Nachricht %2$S - %3$S am %4$S angewendet

--- a/en-GB/mail/chrome/messenger/filter.properties
+++ b/en-GB/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=moved message id = %1$S to %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=copied message id = %1$S to %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Applied filter "%1$S" to message from %2$S - %3$S at %4$S

--- a/en-US/mail/chrome/messenger/filter.properties
+++ b/en-US/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=moved message id = %1$S to %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=copied message id = %1$S to %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Applied filter "%1$S" to message from %2$S - %3$S at %4$S

--- a/es-ES/mail/chrome/messenger/filter.properties
+++ b/es-ES/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=movido mensaje con id = %1$S a %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=copiado mensaje con id = %1$S a %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Aplicado filtro "%1$S" al mensaje de %2$S - %3$S de fecha %4$S

--- a/fr/mail/chrome/messenger/filter.properties
+++ b/fr/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=message id = %1$S déplacé vers %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=message id = %1$S copié vers %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Filtre « %1$S » appliqué au message de %2$S - %3$S le %4$S

--- a/it/mail/chrome/messenger/filter.properties
+++ b/it/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=spostato id del messaggio = %1$S a %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=copiato id del messaggio = %1$S a %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Applicato filtro "%1$S" al messaggio da %2$S - %3$S a %4$S

--- a/nl/mail/chrome/messenger/filter.properties
+++ b/nl/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=bericht-id = %1$S verplaatst naar %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=bericht-id = %1$S gekopieerd naar %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Filter “%1$S” toegepast op bericht van %2$S - %3$S op %4$S

--- a/pt-BR/mail/chrome/messenger/filter.properties
+++ b/pt-BR/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=mensagem movida id = %1$S para %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=mensagem copiada id = %1$S para %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Aplicado filtro “%1$S” na mensagem de %2$S - %3$S em %4$S

--- a/ru/mail/chrome/messenger/filter.properties
+++ b/ru/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=Сообщение с идентификатором «%1$S» пер�
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=Сообщение с идентификатором «%1$S» скопировано в папку «%2$S»
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Фильтр «%1$S» применен к сообщению «%2$S» — «%3$S» в «%4$S»

--- a/sv-SE/mail/chrome/messenger/filter.properties
+++ b/sv-SE/mail/chrome/messenger/filter.properties
@@ -64,6 +64,12 @@ logMoveStr=flyttat meddelande med id = %1$S till %2$S
 # LOCALIZATION NOTE(logCopyStr)
 # %1$S=message id, %2$S=folder URI
 logCopyStr=kopierat meddelande med id = %1$S till %2$S
+# LOCALIZATION NOTE(filterLogLine):
+# %1$S=timestamp, %2$S=log message
+filterLogLine=[%1$S] %2$S
+# LOCALIZATION NOTE(filterMessage):
+# %1$S=filter name, %1$S=log message
+filterMessage=Message from filter "%1$S": %2$S
 # LOCALIZATION NOTE(filterLogDetectStr)
 # %1$S=filter name %2$S=author, %3$S=subject, %4$S=date
 filterLogDetectStr=Använde filtret ”%1$S” på meddelande från %2$S - %3$S - %4$S


### PR DESCRIPTION
Because string formatting is being used, these need to be in translations